### PR TITLE
Skip slack notification for actions where author and reviewer are equal

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -82,6 +82,9 @@ module.exports = {
         `Could not map ${pull_request.user.login} to the users you provided in action.yml`
       );
     }
+    if (author.normalize() === reviewer.normalize()) {
+      return;
+    }
 
     let baseText;
     switch (review.state) {


### PR DESCRIPTION
I'm assuming those messages where it says:

`David, David neither approved nor denied your PR, but merely commented.`
`David, David requested changes on your PR.`
and `David, David approved your PR.` 

aren't that helpful? Feel free to close if you disagree though 🤗 